### PR TITLE
Add SBB temperature

### DIFF
--- a/initcloud_web/biz/phy_monitor/serializer.py
+++ b/initcloud_web/biz/phy_monitor/serializer.py
@@ -23,6 +23,7 @@ class CabinetSerializer(serializers.Serializer):
     jbod_status_02 = serializers.ListField(child=serializers.IntegerField())
     memory_server_status_01 = serializers.ListField(child=serializers.IntegerField())
     memory_server_status_02 = serializers.ListField(child=serializers.IntegerField())
+    ssb_cpu_temp = serializers.ListField()
 
 # PhyMonitorJBOD
 class PhyMonitorJBODSerializer(serializers.Serializer):

--- a/initcloud_web/biz/phy_monitor/views.py
+++ b/initcloud_web/biz/phy_monitor/views.py
@@ -562,7 +562,11 @@ class CabinetDetail(APIView):
             'jbod_status_01': J_DATA['1']['disk'],
             'jbod_status_02': J_DATA['2']['disk'],
             'memory_server_status_01': SS_DATA['disk'][0:20],
-            'memory_server_status_02': SS_DATA['disk'][20:40]
+            'memory_server_status_02': SS_DATA['disk'][20:40],
+            'ssb_cpu_temp': [
+                [SS_DATA['nodes'][0]['cpu1'][0], SS_DATA['nodes'][0]['cpu2'][0]],
+                [SS_DATA['nodes'][1]['cpu1'][0], SS_DATA['nodes'][1]['cpu2'][0]]
+            ]
         }
         serializer = CabinetSerializer(data)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/initcloud_web/biz/storage_monitor/views.py
+++ b/initcloud_web/biz/storage_monitor/views.py
@@ -261,10 +261,10 @@ class StorageBarDetail(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 def get_read_speed():
-    return [[t, randint(0, 1000)] for t in range(25)[::-1]]
+    return [[t, random.randint(0, 1000)] for t in range(25)[::-1]]
 
 def get_write_speed():
-    return [[t, randint(0, 1000)] for t in range(25)[::-1]]
+    return [[t, random.randint(0, 1000)] for t in range(25)[::-1]]
 
 def get_phy_node():
     return {


### PR DESCRIPTION
添加机柜上SBB CPU的温度数据

访问接口： /api/cabinet/

返回数据：
```json
{
  // 其他不变
  sbb_cpu_temp: [[55, 55], [55, 55]]
}
```